### PR TITLE
docs: fix getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,135 @@
 # @gray-adeyi/korapay-sdk
 
-A korapay client SDK for the javascript runtime.
+TypeScript SDK for the Korapay API.
 
-## Features
+## What It Does
 
-- Typescript support
-- Implements methods matching all of korapay's public API.
-- Automatic case transformation of payload and response data keys for a more
-  optimal JS/TS experience
+- Wraps Korapay HTTP endpoints in a typed client.
+- Converts request payloads from camelCase to snake_case automatically.
+- Converts response payloads back to camelCase for JS/TS ergonomics.
+- Supports both secure and public requests through the same client instance.
 
 ## Installation
 
-#### **Npm**
+### npm
 
 ```bash
 npm i @gray-adeyi/korapay-sdk
 ```
 
-#### **Yarn**
+### yarn
 
 ```bash
 yarn add @gray-adeyi/korapay-sdk
 ```
 
-#### **Pnpm**
+### pnpm
 
 ```bash
 pnpm i @gray-adeyi/korapay-sdk
 ```
 
-#### **Bun**
+### bun
 
 ```bash
 bun add @gray-adeyi/korapay-sdk
 ```
 
-#### **Deno**
+### deno
 
 ```bash
 deno add @gray-adeyi/korapay-sdk
 ```
 
-## Usage
+## Quick Start
+
+Set these environment variables before you instantiate the client:
+
+```bash
+KORAPAY_PUBLIC_KEY=pk_test_...
+KORAPAY_SECRET_KEY=sk_test_...
+KORAPAY_ENCRYPTION_KEY=...
+```
+
+Then create the client:
 
 ```ts
-import {
-  type ChargeViaBankTransferPayload,
-  Currency,
-  KorapayClient,
-  type KorapayResponse,
-} from "@gray-adeyi/korapay-sdk";
+import { Country, KorapayClient } from "@gray-adeyi/korapay-sdk";
 
-// Assumes your KORAPAY_PUBLIC_KEY, KORAPAY_SECRET_KEY
-// & KORAPAY_ENCRYPTION_KEY is set in your environmental
-// variables. They can be passed in explicitly on the
-// instantiation which overrides the values set in the environmental
-// variables.
 const client = new KorapayClient();
 
-const response: KorapayResponse = await client.getBalances();
+const balances = await client.getBalances();
+console.log(balances.data);
 
-const payload: ChargeViaBankTransferPayload = {
-  reference: "qwerty",
+const banks = await client.getBanks(Country.NIGERIA);
+console.log(banks.data);
+```
+
+If you want to pass keys explicitly, the constructor accepts them in the same
+order:
+
+```ts
+const client = new KorapayClient(
+  "pk_test_...",
+  "sk_test_...",
+  "encryption_key_here",
+);
+```
+
+## Common Use Cases
+
+### Bank transfer charge
+
+```ts
+import { Currency, KorapayClient } from "@gray-adeyi/korapay-sdk";
+
+const client = new KorapayClient();
+
+const charge = await client.chargeViaBankTransfer({
+  reference: "ref_001",
   customer: { email: "johndoe@example.com" },
   amount: 1_000_000,
   currency: Currency.NGN,
-  narration: "test charge",
-};
-client.chargeViaBankTransfer(payload).then(console.log);
+  narration: "Test charge",
+});
 ```
 
-See the Project's [Documentation](https://gray-adeyi.github.io/korapay-sdk) for
-more
+### Mobile money charge
 
-## Limitations
+```ts
+import { Currency, KorapayClient } from "@gray-adeyi/korapay-sdk";
 
-- Currently, @gray-adeyi/korapay-sdk does not perform any form of validation on
-  the data passed in as method parameters but sends them as is to korapay's
-  servers.
-- Limited documentation
+const client = new KorapayClient();
 
-## Sponsorship
+await client.chargeViaMobileMoney({
+  reference: "ref_002",
+  customer: { email: "johndoe@example.com" },
+  amount: 5000,
+  mobileMoney: { number: 254700000000 },
+  currency: Currency.KES,
+  description: "Mobile money charge",
+});
+```
 
-Every little donation goes a long way. You can also give this project a star in
-its Github repository it helps ♥️
+### Public endpoints
 
-- [Star on Github](https://www.github.com/gray-adeyi/korapay-sdk)
-- [Buy me a coffee](https://www.buymeacoffee.com/jigani)
+Use `getBanks()` and `getMmo()` for public lookup data. These requests use the
+public key.
+
+## Behavior Notes
+
+- The SDK does not validate request payloads before sending them to Korapay.
+- Environment variables are used by default when values are not passed to the
+  constructor.
+- Response keys are normalized to camelCase where possible.
+
+## Documentation
+
+See the docs site for setup and API guidance:
+
+- [Getting started](https://gray-adeyi.github.io/korapay-sdk)
+- [Project documentation](https://gray-adeyi.github.io/korapay-sdk)
 
 ## Contributing
 
-You might encounter bugs while using this project or have feature enhancements
-you'd like to share with the project. Create an issue on the project's
-[github](https://www.github.com/gray-adeyi/korapay-sdk) page.
+If you find a bug or want to propose an improvement, open an issue or submit a pull request.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,20 @@
 # Korapay SDK
 
-hello world
+This documentation covers installation, setup, and the main client flows for
+`@gray-adeyi/korapay-sdk`.
+
+## What To Read First
+
+- [Getting started](getting-started.md)
+
+## What This SDK Does
+
+- Wraps Korapay API endpoints in a typed client.
+- Transforms payload keys to snake_case before sending requests.
+- Transforms response keys back to camelCase after responses are received.
+
+## Current Limitations
+
+- The SDK does not validate payloads before sending them.
+- The test suite still needs mocked coverage for most client methods.
+- Webhook support is not implemented yet.

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -7,4 +7,4 @@
 - Built with Typescript
 - Supports multiple Javascript runtime (Node, Bun, Deno)
 
-[GitHub](https://github.com/gray-adeyi/korapay-sdk) [Get Started](#docsify)
+[GitHub](https://github.com/gray-adeyi/korapay-sdk) [Get Started](#/getting-started)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,11 +22,42 @@ deno add @gray-adeyi/korapay-sdk
 
 <!-- tabs:end -->
 
-```js
+## Configure Your Keys
+
+Set the Korapay keys before creating the client:
+
+```bash
+KORAPAY_PUBLIC_KEY=pk_test_...
+KORAPAY_SECRET_KEY=sk_test_...
+KORAPAY_ENCRYPTION_KEY=...
+```
+
+## Create A Client
+
+```ts
 import { KorapayClient } from "@gray-adeyi/korapay-sdk";
 
-const client = KorapayClient();
-client.getBalances().then((response) => {
-  console.log(response.data);
-});
+const client = new KorapayClient();
+
+const balances = await client.getBalances();
+console.log(balances.data);
 ```
+
+## First Request
+
+If your keys are set correctly, `getBalances()` is a simple first call to verify
+that the client is working.
+
+```ts
+const response = await client.getBalances();
+console.log(response.statusCode);
+console.log(response.message);
+```
+
+## Notes
+
+- Pass keys explicitly to `new KorapayClient(publicKey, secretKey, encryptionKey)`
+  if you do not want to rely on environment variables.
+- `getBanks()` is a public endpoint and uses the public key.
+- `chargeViaCard()` requires an encryption key because the card payload is
+  encrypted before it is sent.


### PR DESCRIPTION
## Summary
Rewrite the project docs to make onboarding clearer and fix broken examples in the docs site.

## Changes
- Replace the placeholder docs home page
- Rewrite the root README with a real quick start flow
- Fix the getting started example
- Update the cover page CTA to point at the real getting started page

## Out of scope
- No SDK behavior changes
- No endpoint cleanup
- No test changes

## Verification
- Confirm the README renders correctly on GitHub
- Confirm the docs site opens to the updated home page
- Confirm the cover page "Get Started" CTA lands on `#/getting-started`