### PR TITLE
Replace the old live-default test setup with a mocked unit suite and keep the live Korapay checks as an opt-in integration suite.

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -6,7 +6,9 @@
   "exports": "./mod.ts",
   "license": "MIT",
   "tasks": {
-    "dev": "deno test --watch mod.ts"
+    "dev": "deno test --watch mod.ts",
+    "test": "deno test tests/korapay_test.ts tests/restClient_test.ts",
+    "test:live": "KORAPAY_LIVE_TESTS=1 deno test --allow-env --allow-read=.env --allow-net=api.korapay.com tests/live/korapay_live.ts"
   },
   "imports": {
     "@deno/dnt": "jsr:@deno/dnt@^0.41.3",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -17,5 +17,8 @@
     "@std/testing": "jsr:@std/testing@^1.0.8",
     "axios": "npm:axios@^1.7.9",
     "lodash-es": "npm:lodash-es@^4.17.21"
+  },
+  "fmt": {
+    "exclude": ["**/*.md"]
   }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
 export { default as KorapayClient } from "./src/korapay.ts";
 export * from "./src/types/global.ts";
-export * from "./src/types/responseModels.ts"
+export * from "./src/types/responseModels.ts";
 export * from "./src/enums.ts";

--- a/src/restClient.ts
+++ b/src/restClient.ts
@@ -73,7 +73,7 @@ export default class RestClient {
     // deno-lint-ignore no-explicit-any
     data?: any,
     noAuth = false,
-  // deno-lint-ignore no-explicit-any
+    // deno-lint-ignore no-explicit-any
   ): Promise<KorapayResponse<any>> {
     const handler = this.getMethodHandler(method, noAuth);
     let response: AxiosResponse;

--- a/src/types/responseModels.ts
+++ b/src/types/responseModels.ts
@@ -323,7 +323,7 @@ export type GetPayoutsData = {
   payouts: UnifiedPayout[];
 };
 
-export type Balance = Record<'ghs' | 'kes'  | 'ngn' | 'usd', {
+export type Balance = Record<"ghs" | "kes" | "ngn" | "usd", {
   readonly pendingBalance: number;
   readonly availableBalance: number;
 }>;

--- a/tests/korapay_test.ts
+++ b/tests/korapay_test.ts
@@ -1,115 +1,174 @@
-import { beforeAll, describe, it } from "@std/testing/bdd";
 import { assertEquals } from "@std/assert";
+import { Country, Currency, HTTPMethod } from "../src/enums.ts";
 import KorapayClient from "../src/korapay.ts";
-import { Country } from "../src/enums.ts";
-import { load } from "@std/dotenv";
+import type RestClient from "../src/restClient.ts";
+import type { KorapayResponse } from "../src/types/global.ts";
+import type { Balance, Bank, MMO } from "../src/types/responseModels.ts";
 
-describe("KorapayClient", () => {
-  let client: KorapayClient;
+type CallRecord = {
+  endpoint: string;
+  method: HTTPMethod;
+  data?: unknown;
+  noAuth: boolean;
+};
 
-  beforeAll(async () => {
-    await load({ envPath: ".env", export: true });
-    client = new KorapayClient();
+function createMockClient(responseData: unknown = { ok: true }) {
+  const calls: CallRecord[] = [];
+
+  return {
+    calls,
+    async encryptData(data: unknown) {
+      calls.push({
+        endpoint: "encryptData",
+        method: HTTPMethod.POST,
+        data,
+        noAuth: false,
+      });
+      return "encrypted-payload";
+    },
+    async call(
+      endpoint: string,
+      method: HTTPMethod,
+      data?: unknown,
+      noAuth = false,
+    ): Promise<KorapayResponse<unknown>> {
+      calls.push({ endpoint, method, data, noAuth });
+      return {
+        statusCode: 200,
+        status: true,
+        message: "success",
+        data: responseData,
+      };
+    },
+  };
+}
+
+function createClient(mock: ReturnType<typeof createMockClient>) {
+  return new KorapayClient(
+    "pk_live_dummy",
+    "sk_live_dummy",
+    "01234567890123456789012345678901",
+    mock as unknown as RestClient,
+    true,
+  );
+}
+
+Deno.test("KorapayClient delegates balances requests to the secure client", async () => {
+  const balanceData = {
+    ngn: { availableBalance: 100, pendingBalance: 0 },
+    kes: { availableBalance: 0, pendingBalance: 0 },
+    ghs: { availableBalance: 0, pendingBalance: 0 },
+    usd: { availableBalance: 0, pendingBalance: 0 },
+  } satisfies Balance;
+  const mock = createMockClient(balanceData);
+  const client = createClient(mock);
+
+  const response = await client.getBalances();
+
+  assertEquals(mock.calls[0], {
+    endpoint: "/merchant/api/v1/balances",
+    method: HTTPMethod.GET,
+    data: undefined,
+    noAuth: false,
+  });
+  assertEquals(response.data, balanceData);
+});
+
+Deno.test("KorapayClient uses the public auth path for bank lookup endpoints", async () => {
+  const banks = [
+    {
+      name: "Guaranty Trust Bank",
+      slug: "gtbank",
+      code: "058",
+      nibssBankCode: "058",
+      country: Country.NIGERIA,
+    },
+  ] satisfies Bank[];
+  const mock = createMockClient(banks);
+  const client = createClient(mock);
+
+  const response = await client.getBanks(Country.NIGERIA);
+
+  assertEquals(mock.calls[0], {
+    endpoint: "/merchant/api/v1/misc/banks?countryCode=NG",
+    method: HTTPMethod.GET,
+    data: undefined,
+    noAuth: true,
+  });
+  assertEquals(response.data, banks);
+});
+
+Deno.test("KorapayClient uses the public auth path for mobile money lookup endpoints", async () => {
+  const mmos = [
+    {
+      name: "MTN Ghana",
+      slug: "mtn-gh",
+      country: Country.GHANA,
+      code: "mtn-gh",
+      min: 1,
+      max: 100000,
+    },
+  ] satisfies MMO[];
+  const mock = createMockClient(mmos);
+  const client = createClient(mock);
+
+  const response = await client.getMmo(Country.GHANA);
+
+  assertEquals(mock.calls[0], {
+    endpoint: "/merchant/api/v1/misc/mobile-money?countryCode=GH",
+    method: HTTPMethod.GET,
+    data: undefined,
+    noAuth: true,
+  });
+  assertEquals(response.data, mmos);
+});
+
+Deno.test("KorapayClient encrypts card payloads before sending them", async () => {
+  const mock = createMockClient({ reference: "ref_001" });
+  const client = createClient(mock);
+
+  await client.chargeViaCard({
+    reference: "ref_001",
+    customer: {
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+    },
+    card: {
+      number: "5399831111111111",
+      cvv: "100",
+      expiryMonth: "10",
+      expiryYear: "31",
+    },
+    amount: 5000,
+    currency: Currency.NGN,
   });
 
-  it.skip("chargeViaCard", () => {
+  assertEquals(mock.calls[0], {
+    endpoint: "encryptData",
+    method: HTTPMethod.POST,
+    data: {
+      reference: "ref_001",
+      customer: {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+      },
+      card: {
+        number: "5399831111111111",
+        cvv: "100",
+        expiryMonth: "10",
+        expiryYear: "31",
+      },
+      amount: 5000,
+      currency: Currency.NGN,
+    },
+    noAuth: false,
   });
-
-  it.skip("authorizeCardCharge", () => {});
-
-  it.skip("resendCardOtp", () => {});
-
-  it.skip("chargeViaBankTransfer", () => {});
-
-  it.skip("createVirtualBankAccount", () => {});
-
-  it.skip("getVirtualBankAccount", () => {});
-
-  it.skip("getVirtualBankAccountTransactions", () => {});
-
-  it.skip("creditSandboxVirtualBankAccount", () => {});
-
-  it.skip("chargeViaMobileMoney", () => {});
-
-  it.skip("authorizeMobileMoneyCharge", () => {});
-
-  it.skip("resendMobileMoneyOtp", () => {});
-
-  it.skip("resendSkt", () => {});
-
-  it.skip("authorizeSkt", () => {});
-
-  it.skip("initiateCharge", () => {});
-
-  it.skip("chargeViaDirectBankDebit", () => {});
-
-  it.skip("getCharge", () => {});
-
-  it.skip("getPayins", () => {});
-
-  it.skip("initiateRefund", () => {});
-
-  it.skip("getRefund", () => {});
-
-  it.skip("getRefundHistory", () => {});
-
-  it.skip("payoutToBankAccount", () => {});
-
-  it.skip("payoutToMobileMoney", () => {});
-
-  it.skip("remitToBankAccount", () => {});
-
-  it.skip("remitToMobileMoney", () => {});
-
-  it.skip("bulkPayoutToBankAccount", () => {});
-
-  it.skip("getPayoutsInBulkPayoutToBankAccount", () => {});
-
-  it.skip("getBulkPayoutToBankAccount", () => {});
-
-  it.skip("getPayoutTransaction", () => {});
-
-  it.skip("getPayouts", () => {});
-
-  it.skip("resolveBankAccount", () => {});
-
-  it("getBalances", async () => {
-    const response = await client.getBalances();
-    assertEquals(response.statusCode, 200);
-    assertEquals(response.message, 'success')
-  });
-
-  it.skip("getBalanceHistory", () => {});
-
-  it.skip("initiateRateConversion", () => {});
-
-  it.skip("completeRateConversion", () => {});
-
-  it.skip("getRateConversions", () => {});
-
-  it.skip("getRateConversion", () => {});
-
-  it.skip("createCard", () => {});
-
-  it.skip("getCard", () => {});
-
-  it.skip("getCards", () => {});
-
-  it.skip("fundCard", () => {});
-
-  it.skip("withdrawFromCard", () => {});
-
-  it.skip("updateCardStatus", () => {});
-
-  it.skip("createCardHolder", () => {});
-
-  it.skip("getCardTransactions", () => {});
-
-  it("getBanks", async () => {
-    const response = await client.getBanks(Country.NIGERIA);
-    console.log(response);
-  });
-
-  it.skip("getMmo", async () => {
+  assertEquals(mock.calls[1], {
+    endpoint: "/merchant/api/v1/charges/card",
+    method: HTTPMethod.POST,
+    data: {
+      chargeData: "encrypted-payload",
+    },
+    noAuth: false,
   });
 });

--- a/tests/live/korapay_live.ts
+++ b/tests/live/korapay_live.ts
@@ -1,0 +1,63 @@
+import { assertEquals } from "@std/assert";
+import { load } from "@std/dotenv";
+
+import { Country } from "../../src/enums.ts";
+import KorapayClient from "../../src/korapay.ts";
+
+async function canRunLiveTests(): Promise<boolean> {
+  if (Deno.env.get("KORAPAY_LIVE_TESTS") !== "1") {
+    return false;
+  }
+
+  try {
+    await Deno.stat(".env");
+    await load({
+      envPath: ".env",
+      export: true,
+    });
+  } catch {
+    console.warn("Skipping live tests: .env file not found");
+    return false;
+  }
+
+  const requiredEnvVars = [
+    "KORAPAY_PUBLIC_KEY",
+    "KORAPAY_SECRET_KEY",
+  ];
+
+  for (const key of requiredEnvVars) {
+    if (!Deno.env.get(key)) {
+      console.warn(
+        `Skipping live tests: missing required environment variable ${key}`,
+      );
+      return false;
+    }
+  }
+
+  return true;
+}
+
+if (await canRunLiveTests()) {
+  const client = new KorapayClient();
+
+  Deno.test("live: getBalances", async () => {
+    const response = await client.getBalances();
+
+    assertEquals(response.statusCode, 200);
+    assertEquals(response.message, "success");
+  });
+
+  Deno.test("live: getBanks", async () => {
+    const response = await client.getBanks(Country.NIGERIA);
+
+    assertEquals(response.statusCode, 200);
+    assertEquals(Array.isArray(response.data), true);
+  });
+
+  Deno.test("live: getMmo", async () => {
+    const response = await client.getMmo(Country.GHANA);
+
+    assertEquals(response.statusCode, 200);
+    assertEquals(Array.isArray(response.data), true);
+  });
+}

--- a/tests/restClient_test.ts
+++ b/tests/restClient_test.ts
@@ -1,27 +1,188 @@
-import { assertEquals } from "@std/assert";
-import { describe, it } from "@std/testing/bdd";
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { HTTPMethod } from "../src/enums.ts";
+import { KorapayClientError } from "../src/errors.ts";
 import RestClient from "../src/restClient.ts";
 
-describe("RestClient", () => {
-  describe("publicKey", () => {});
-  describe("privateKey", () => {});
-  describe("encryptionKey", () => {});
+function createResponse(
+  status: number,
+  data: Record<string, unknown>,
+) {
+  return { status, data };
+}
 
-  it("camelToSnakeCaseTransformer", () => {
-    const data = { firstName: "john", lastName: "doe", DOB: "2024-08-30" };
-    const expected = {
-      first_name: "john",
-      last_name: "doe",
-      dob: "2024-08-30",
-    };
-    const got = RestClient.camelToSnakeCaseTransformer(data);
-    assertEquals(got, expected);
-  });
+Deno.test("RestClient transforms nested camelCase payloads to snake_case", () => {
+  const data = {
+    firstName: "john",
+    accountDetails: {
+      bankCode: "058",
+      nestedItems: [{ itemName: "one" }, { itemName: "two" }],
+    },
+    DOB: "2024-08-30",
+  };
 
-  it("snakeToCamelCaseTransformer", () => {
-    const data = { first_name: "john", last_name: "doe", dob: "2024-08-30" };
-    const expected = { firstName: "john", lastName: "doe", dob: "2024-08-30" };
-    const got = RestClient.snakeToCamelCaseTransformer(data);
-    assertEquals(got, expected);
+  const got = RestClient.camelToSnakeCaseTransformer(data);
+
+  assertEquals(got, {
+    first_name: "john",
+    account_details: {
+      bank_code: "058",
+      nested_items: [{ item_name: "one" }, { item_name: "two" }],
+    },
+    dob: "2024-08-30",
   });
+});
+
+Deno.test("RestClient transforms nested snake_case payloads to camelCase", () => {
+  const data = {
+    first_name: "john",
+    account_details: {
+      bank_code: "058",
+      nested_items: [{ item_name: "one" }, { item_name: "two" }],
+    },
+    dob: "2024-08-30",
+  };
+
+  const got = RestClient.snakeToCamelCaseTransformer(data);
+
+  assertEquals(got, {
+    firstName: "john",
+    accountDetails: {
+      bankCode: "058",
+      nestedItems: [{ itemName: "one" }, { itemName: "two" }],
+    },
+    dob: "2024-08-30",
+  });
+});
+
+Deno.test("RestClient builds the correct auth headers for open and secure clients", () => {
+  const client = new RestClient(
+    "pk_test",
+    "sk_test",
+    "01234567890123456789012345678901",
+  );
+  const openHeaders = (client as any).openHeaders;
+  const secureHeaders = (client as any).secureHeaders;
+
+  assertEquals(openHeaders.Authorization, "Bearer pk_test");
+  assertEquals(secureHeaders.Authorization, "Bearer sk_test");
+  assertEquals(openHeaders["User-Agent"], "@gray-adeyi/korapay-sdk 0.3.0");
+  assertEquals(secureHeaders["User-Agent"], "@gray-adeyi/korapay-sdk 0.3.0");
+});
+
+Deno.test("RestClient routes GET requests through the secure client by default", async () => {
+  const client = new RestClient(
+    "pk_test",
+    "sk_test",
+    "01234567890123456789012345678901",
+  );
+  const calls: Array<{ endpoint: string }> = [];
+
+  (client as any).secureClient = {
+    get: async (endpoint: string) => {
+      calls.push({ endpoint });
+      return createResponse(200, {
+        status: true,
+        message: "success",
+        data: { reference: "ref_001" },
+      });
+    },
+  };
+
+  const response = await client.call(
+    "/merchant/api/v1/balances",
+    HTTPMethod.GET,
+  );
+
+  assertEquals(calls, [{ endpoint: "/merchant/api/v1/balances" }]);
+  assertEquals(response, {
+    statusCode: 200,
+    status: true,
+    message: "success",
+    data: { reference: "ref_001" },
+  });
+});
+
+Deno.test("RestClient routes no-auth POST requests through the open client", async () => {
+  const client = new RestClient(
+    "pk_test",
+    "sk_test",
+    "01234567890123456789012345678901",
+  );
+  const calls: Array<{ endpoint: string; data: unknown }> = [];
+
+  (client as any).openClient = {
+    post: async (endpoint: string, data: unknown) => {
+      calls.push({ endpoint, data });
+      return createResponse(200, {
+        status: true,
+        message: "success",
+        data: { reference: "ref_002" },
+      });
+    },
+  };
+
+  const payload = { countryCode: "NG" };
+  const response = await client.call(
+    "/merchant/api/v1/misc/banks",
+    HTTPMethod.POST,
+    payload,
+    true,
+  );
+
+  assertEquals(calls, [{
+    endpoint: "/merchant/api/v1/misc/banks",
+    data: payload,
+  }]);
+  assertEquals(response.statusCode, 200);
+  assertEquals(response.data, { reference: "ref_002" });
+});
+
+Deno.test("RestClient wraps request errors in KorapayClientError", async () => {
+  const client = new RestClient(
+    "pk_test",
+    "sk_test",
+    "01234567890123456789012345678901",
+  );
+
+  await assertRejects(
+    () =>
+      (client as any).handleRequestError({
+        message: "request failed",
+        status: 401,
+        code: "ERR_BAD_REQUEST",
+      }),
+    KorapayClientError,
+  );
+});
+
+Deno.test("RestClient wraps response errors in KorapayClientError", async () => {
+  const client = new RestClient(
+    "pk_test",
+    "sk_test",
+    "01234567890123456789012345678901",
+  );
+
+  await assertRejects(
+    () =>
+      (client as any).handleResponseError({
+        message: "response failed",
+        status: 500,
+        code: "ERR_BAD_RESPONSE",
+      }),
+    KorapayClientError,
+  );
+});
+
+Deno.test("RestClient encrypts payloads into iv:ciphertext:tag format", async () => {
+  const client = new RestClient(
+    "pk_test",
+    "sk_test",
+    "01234567890123456789012345678901",
+  );
+  const encrypted = await client.encryptData({ reference: "ref_001" });
+
+  const parts = encrypted.split(":");
+
+  assertEquals(parts.length, 3);
+  assert(parts.every((part) => part.length > 0));
 });


### PR DESCRIPTION
## Changes
- Add mocked tests for `KorapayClient` behavior
- Add `RestClient` coverage for auth routing, payload transformation, error wrapping, and encryption
- Move live Korapay checks into a separate opt-in test file
- Add Deno tasks for:
    - `test`
    - `test:live`

## How to run
- `deno task test` for the default mocked suite
- `deno task test:live` for live Korapay checks

## Notes
- Live tests are gated behind `KORAPAY_LIVE_TESTS=1`
- Live tests require `.env` and Korapay credentials